### PR TITLE
Modernize CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,33 +18,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: check
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check
 
   fmt-check:
     name: cargo fmt --check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: rustfmt
-      - name: print rustfmt version
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --version
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check --color=always
+      - run: rustup toolchain install stable --profile minimal --component rustfmt
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --version
+      - run: cargo fmt --all -- --check --color=always
 
   test-rust:
     name: cargo test
@@ -57,29 +43,19 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - run: rustup toolchain install stable --profile minimal
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build
+      - run: cargo test
+
+  package:
+    uses: ./.github/workflows/package.yml
 
   clippy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          components: clippy
-      - name: print clippy version
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --version
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets --all-features -- -D warnings
+      - run: rustup toolchain install stable --profile minimal --component clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --version
+      - run: cargo clippy --all-targets --all-features -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,9 +48,6 @@ jobs:
       - run: cargo build
       - run: cargo test
 
-  package:
-    uses: ./.github/workflows/package.yml
-
   clippy:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Originally when I created this repo, I just ripped off the CI from https://github.com/dotboris/alt. Recently I reworked that CI because it was using the now unmaintained `actions-rs/*` actions. https://github.com/dotboris/alt/issues/281

In this PR, I'm ripping off the new updated CI

This gives us caching for cargo and fixes a bunch of deprecations.