### PR TITLE
Fix flake on macos

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
       commonArgs = {
         inherit src;
         strictDeps = true;
+        buildInputs = pkgs.lib.optionals pkgs.stdenv.isDarwin [
+          # Additional darwin specific inputs can be set here
+          pkgs.libiconv
+        ];
       };
       cargoArtifacts = craneLib.buildDepsOnly commonArgs;
       cdo = craneLib.buildPackage (commonArgs


### PR DESCRIPTION
The build was failing with

```
ld: library not found for -liconv
```